### PR TITLE
Adding staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ This is a debian-based image which runs an apache and get's it SSL-certificates 
 
 ### Prepare your apache-config
 There are some things you have to care about in your apache-config if you want to use it with certbot:
+
 * for every domain given in `DOMAINS` there must be a apache-vhost which uses this domain as `ServerName` or `ServerAlias`. Else certbot won't get a certificate for this domain.
 * certbot does not support multiple vhosts in a config-file yet. If an config-file has more than a single vhost it will be ignored by certbot.
 
 ### Run it
 For an easy test-startup you just have to:
+
 ```
 $ docker run -d --name apache-ssl birgerk/apache-letsencrypt
 ```
@@ -20,6 +22,7 @@ Now you have locally an apache running, which get's it SSL-certificates from Let
 The image will get letsencrypt-certificates on first boot. A cron-job renews the existing certificates automatically, so you don't have to care about it.
 
 If you want to expand your certificate and you can remove the existing docker-container and start new one with the updated `DOMAINS`-list. If you don't want to recreate the container you can execute the following commands:
+
 ```
 $ $UPDATED_DOMAINS="example.org,more.example.org"
 $ docker exec -it apache-ssl /run_letsencrypt.sh --domains $UPDATED_DOMAINS
@@ -28,5 +31,7 @@ $ docker exec -it apache-ssl /run_letsencrypt.sh --domains $UPDATED_DOMAINS
 
 ### Configuring docker-container
 It's possible to configure the docker-container by setting the following environment-variables at container-startup:
+
 * `DOMAINS`, configures which for which domains a SSL-certificate shall be requested from Let's Encrypt, default is `""`. Must be given as comma-seperated list, f.e.: `"example.com,my-internet.org,more.example.com"`.
 * `WEBMASTER_MAIL`, Let's Encrypt needs a mail-address from the webmaster of the requested domain. You have to set it, otherwise Let's Encrypt won't give the certificates. Default is `""`. Must be given as simple mail-address, f.e.: `"webmaster@example.com"`.
+* `STAGING`, if set with a not-null string use Let's Encrypt Staging environment to avoid rate limits during development.

--- a/config/scripts/run_letsencrypt.sh
+++ b/config/scripts/run_letsencrypt.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
-
-letsencrypt -n --expand --apache --agree-tos --email $WEBMASTER_MAIL "$@"
+if (! [ -z "$STAGING" ]) then
+  echo "Using Let's Encrypt Staging environment..."
+  letsencrypt -n --staging --expand --apache --agree-tos --email $WEBMASTER_MAIL "$@"
+else
+  echo "Using Let's Encrypt Productioun environment..."
+  letsencrypt -n --expand --apache --agree-tos --email $WEBMASTER_MAIL "$@"
+fi


### PR DESCRIPTION
During my test with this docker container I'm faced the rate-limit provided by Let's Encrypt, so I decided add a new STAGING environment that if set to true or any other non null string will set the `--staging` param on letsencrypt command.
I think it's useful to test the creation of certificates during development