### PR TITLE
Refactor/ubuntu supervisord

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:master-amd64
 MAINTAINER Nicolas Richeton <nicolas.richeton@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ CMD ["/sbin/my_init"]
 
 # Base setup
 RUN apt-get -y update && \
+    apt-get -y dist-upgrade &&\
     apt-get install -q -y curl apache2 software-properties-common dumb-init && \
 #    add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,13 @@ ENV WEBMASTER_MAIL ""
 RUN echo $WEBMASTER_MAIL > /etc/container_environment/WEBMASTER_MAIL && \
     echo $DOMAINS > /etc/container_environment/DOMAINS && \
     echo $LETSENCRYPT_HOME > /etc/container_environment/LETSENCRYPT_HOME
-
+    
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/sbin/my_init"]
 
 # Base setup
 RUN apt-get -y update && \
-    apt-get install -q -y curl apache2 software-properties-common && \
+    apt-get install -q -y curl apache2 software-properties-common dumb-init && \
 #    add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \
     apt-get install -q -y python3-certbot-apache && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get -y update && \
     add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \
     apt-get install -q -y python-certbot-apache && \
+    # Add modsecurity
+    apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -41,4 +43,5 @@ RUN chmod +x /*.sh && chmod +x /etc/my_init.d/*.sh && chmod +x /etc/service/apac
 # Stuff
 EXPOSE 80
 EXPOSE 443
-VOLUME [ "$LETSENCRYPT_HOME", "/etc/apache2/sites-available", "/var/log/apache2" ]
+
+#VOLUME [ "$LETSENCRYPT_HOME", "/etc/apache2/sites-available", "/var/log/apache2" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update && \
     apt-get install -q -y curl apache2 software-properties-common && \
 #    add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \
-    apt-get install -q -y python-certbot-apache && \
+    apt-get install -q -y python3-certbot-apache && \
     # Add modsecurity
     apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
     apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:master-amd64
+FROM phusion/baseimage:jammy-1.0.1
 MAINTAINER Nicolas Richeton <nicolas.richeton@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM phusion/baseimage:0.11
-MAINTAINER BirgerK <birger.kamp@gmail.com>
+MAINTAINER Nicolas Richeton <nicolas.richeton@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LETSENCRYPT_HOME /etc/letsencrypt
@@ -45,3 +45,4 @@ EXPOSE 80
 EXPOSE 443
 
 #VOLUME [ "$LETSENCRYPT_HOME", "/etc/apache2/sites-available", "/var/log/apache2" ]
+HEALTHCHECK CMD curl --fail http://localhost/ || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ CMD ["/sbin/my_init"]
 # Base setup
 RUN apt-get -y update && \
     apt-get install -q -y curl apache2 software-properties-common && \
-    add-apt-repository ppa:certbot/certbot && \
+#    add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \
     apt-get install -q -y python-certbot-apache && \
     # Add modsecurity

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ ADD config/scripts/init_letsencrypt.sh /etc/my_init.d/
 ADD config/scripts/run_letsencrypt.sh /run_letsencrypt.sh
 RUN chmod +x /*.sh && chmod +x /etc/my_init.d/*.sh && chmod +x /etc/service/apache/*
 
+ADD config/crontab /etc/crontab
+
 # Stuff
 EXPOSE 80
 EXPOSE 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:jammy-1.0.1
+FROM phusion/baseimage:noble
 MAINTAINER Nicolas Richeton <nicolas.richeton@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,20 @@
-FROM phusion/baseimage:noble
+FROM debian:bookworm-slim
 MAINTAINER Nicolas Richeton <nicolas.richeton@gmail.com>
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV LETSENCRYPT_HOME /etc/letsencrypt
-ENV DOMAINS ""
-ENV WEBMASTER_MAIL ""
-
-# Manually set the apache environment variables in order to get apache to work immediately.
-RUN echo $WEBMASTER_MAIL > /etc/container_environment/WEBMASTER_MAIL && \
-    echo $DOMAINS > /etc/container_environment/DOMAINS && \
-    echo $LETSENCRYPT_HOME > /etc/container_environment/LETSENCRYPT_HOME
-    
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/sbin/my_init"]
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LETSENCRYPT_HOME=/etc/letsencrypt
+ENV DOMAINS=""
+ENV WEBMASTER_MAIL=""
 
 # Base setup
 RUN apt-get -y update && \
-    apt-get -y dist-upgrade &&\
-    apt-get install -q -y curl apache2 software-properties-common dumb-init && \
-#    add-apt-repository ppa:certbot/certbot && \
-    apt-get -y update && \
+    apt-get -y dist-upgrade && \
+    apt-get install -q -y \
+        curl apache2 dumb-init \
+        supervisor cron rsyslog && \
     apt-get install -q -y python3-certbot-apache && \
     # Add modsecurity
-    apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
+    apt-get install -q -y --no-install-recommends libapache2-mod-security2 modsecurity-crs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -35,18 +27,30 @@ RUN echo "ServerName localhost" >> /etc/apache2/conf-enabled/hostname.conf && \
     mkdir -p /var/lock/apache2 && \
     mkdir -p /var/run/apache2
 
-# configure runit
-RUN mkdir -p /etc/service/apache
+# scripts
 ADD config/scripts/run_apache.sh /etc/service/apache/run
-ADD config/scripts/init_letsencrypt.sh /etc/my_init.d/
+ADD config/scripts/init_letsencrypt.sh /init_letsencrypt.sh
 ADD config/scripts/run_letsencrypt.sh /run_letsencrypt.sh
-RUN chmod +x /*.sh && chmod +x /etc/my_init.d/*.sh && chmod +x /etc/service/apache/*
+ADD config/scripts/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /*.sh /etc/service/apache/run
 
 ADD config/crontab /etc/crontab
 
-# Stuff
+# supervisor + syslog
+ADD config/supervisord.conf /etc/supervisord.conf
+ADD config/rsyslog.conf /etc/rsyslog.conf
+RUN mkdir -p /var/log/supervisor/
+
 EXPOSE 80
 EXPOSE 443
 
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["/docker-entrypoint.sh"]
+
 #VOLUME [ "$LETSENCRYPT_HOME", "/etc/apache2/sites-available", "/var/log/apache2" ]
-HEALTHCHECK CMD curl --fail http://localhost/ || exit 1
+# Accept any HTTP response (including 302/403) as healthy — Apache just needs to be up.
+# start-period=120s covers the initial Let's Encrypt certificate request on first boot.
+# Redirect all curl output to /dev/null to keep healthcheck logs clean.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=5 \
+  CMD curl -s --max-time 5 -o /dev/null http://localhost/ >/dev/null 2>&1 || \
+      curl -sk --max-time 5 -o /dev/null https://localhost/ >/dev/null 2>&1 || exit 1

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -11,9 +11,9 @@ ENV DOMAINS ""
 ENV WEBMASTER_MAIL ""
 
 # Manually set the apache environment variables in order to get apache to work immediately.
-RUN echo $WEBMASTER_MAIL > /etc/container_environment/WEBMASTER_MAIL && \
-    echo $DOMAINS > /etc/container_environment/DOMAINS && \
-    echo $LETSENCRYPT_HOME > /etc/container_environment/LETSENCRYPT_HOME
+#RUN echo $WEBMASTER_MAIL > /etc/container_environment/WEBMASTER_MAIL && \
+#    echo $DOMAINS > /etc/container_environment/DOMAINS && \
+#    echo $LETSENCRYPT_HOME > /etc/container_environment/LETSENCRYPT_HOME
 
 # Base setup
 RUN apt-get -y update && \

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -1,0 +1,55 @@
+FROM  balenalib/armv7hf-debian:buster
+
+# Enable building ARM container on x86 machinery on the web (comment out next line if built on Raspberry)
+RUN [ "cross-build-start" ]
+
+MAINTAINER Nicolas Richeton <nicolas.richeton@gmail.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LETSENCRYPT_HOME /etc/letsencrypt
+ENV DOMAINS ""
+ENV WEBMASTER_MAIL ""
+
+# Manually set the apache environment variables in order to get apache to work immediately.
+RUN echo $WEBMASTER_MAIL > /etc/container_environment/WEBMASTER_MAIL && \
+    echo $DOMAINS > /etc/container_environment/DOMAINS && \
+    echo $LETSENCRYPT_HOME > /etc/container_environment/LETSENCRYPT_HOME
+
+CMD ["/sbin/my_init"]
+
+# Base setup
+RUN apt-get -y update && \
+    apt-get install -q -y curl apache2 software-properties-common && \
+    add-apt-repository ppa:certbot/certbot && \
+    apt-get -y update && \
+    apt-get install -q -y python-certbot-apache && \
+    # Add modsecurity
+    apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# configure apache
+ADD config/mods-available/proxy_html.conf /etc/apache2/mods-available/
+ADD config/conf-available/security.conf /etc/apache2/conf-available/
+RUN echo "ServerName localhost" >> /etc/apache2/conf-enabled/hostname.conf && \
+    a2enmod ssl headers proxy proxy_http proxy_html xml2enc rewrite usertrack remoteip && \
+    a2dissite 000-default default-ssl && \
+    mkdir -p /var/lock/apache2 && \
+    mkdir -p /var/run/apache2
+
+# configure runit
+RUN mkdir -p /etc/service/apache
+ADD config/scripts/run_apache.sh /etc/service/apache/run
+ADD config/scripts/init_letsencrypt.sh /etc/my_init.d/
+ADD config/scripts/run_letsencrypt.sh /run_letsencrypt.sh
+RUN chmod +x /*.sh && chmod +x /etc/my_init.d/*.sh && chmod +x /etc/service/apache/*
+
+# Stuff
+EXPOSE 80
+EXPOSE 443
+
+#VOLUME [ "$LETSENCRYPT_HOME", "/etc/apache2/sites-available", "/var/log/apache2" ]
+HEALTHCHECK CMD curl --fail http://localhost/ || exit 1
+
+# stop processing ARM emulation (comment out next line if built on Raspberry)
+RUN [ "cross-build-end" ]

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -17,6 +17,7 @@ ENV WEBMASTER_MAIL ""
 
 # Base setup
 RUN apt-get -y update && \
+    apt-get -y dist-upgrade && \
     apt-get install -q -y curl apache2 software-properties-common dumb-init && \
 #    add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -29,7 +29,7 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add supervisor
-RUN pip install wheel && pip install supervisor supervisor-stdout
+RUN pip install wheel && pip install supervisor git+https://github.com/coderanger/supervisor-stdout
 
 # configure apache
 ADD config/mods-available/proxy_html.conf /etc/apache2/mods-available/

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -24,7 +24,7 @@ RUN apt-get -y update && \
     # Add modsecurity
     apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
     # Add cron & python
-    apt-get install -q -y --no-install-recommends  cron python-setuptools python-pip && \ 
+    apt-get install -q -y --no-install-recommends  cron python-setuptools python-pip rsyslog && \ 
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -24,7 +24,7 @@ RUN apt-get -y update && \
     # Add modsecurity
     apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
     # Add cron & python
-    apt-get install -q -y --no-install-recommends  cron python-setuptools python-pip rsyslog && \ 
+    apt-get install -q -y --no-install-recommends  cron python-setuptools python3-pip rsyslog && \ 
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -15,7 +15,7 @@ RUN echo $WEBMASTER_MAIL > /etc/container_environment/WEBMASTER_MAIL && \
     echo $DOMAINS > /etc/container_environment/DOMAINS && \
     echo $LETSENCRYPT_HOME > /etc/container_environment/LETSENCRYPT_HOME
 
-CMD ["/sbin/my_init"]
+#CMD ["/sbin/my_init"]
 
 # Base setup
 RUN apt-get -y update && \

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -20,7 +20,7 @@ RUN apt-get -y update && \
     apt-get install -q -y curl apache2 software-properties-common dumb-init && \
 #    add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \
-    apt-get install -q -y python-certbot-apache && \
+    apt-get install -q -y python3-certbot-apache && \
     # Add modsecurity
     apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
     # Add cron & python

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -25,8 +25,13 @@ RUN apt-get -y update && \
     apt-get install -q -y python-certbot-apache && \
     # Add modsecurity
     apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
+    # Add cron 
+    apt-get install -q -y --no-install-recommends  cron  && \ 
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add supervisor
+RUN pip install wheel && pip install supervisor supervisor-stdout
 
 # configure apache
 ADD config/mods-available/proxy_html.conf /etc/apache2/mods-available/
@@ -44,7 +49,12 @@ ADD config/scripts/init_letsencrypt.sh /etc/my_init.d/
 ADD config/scripts/run_letsencrypt.sh /run_letsencrypt.sh
 RUN chmod +x /*.sh && chmod +x /etc/my_init.d/*.sh && chmod +x /etc/service/apache/*
 
+# Cron
 ADD config/crontab /etc/crontab
+
+# Supervisor 
+ADD config/supervisord.conf /etc/supervisord.conf
+ADD config/rsyslog.conf /etc/rsyslog.conf
 
 # Stuff
 EXPOSE 80

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -18,7 +18,7 @@ ENV WEBMASTER_MAIL ""
 # Base setup
 RUN apt-get -y update && \
     apt-get install -q -y curl apache2 software-properties-common dumb-init && \
-    add-apt-repository ppa:certbot/certbot && \
+#    add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \
     apt-get install -q -y python-certbot-apache && \
     # Add modsecurity

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -43,9 +43,9 @@ RUN echo "ServerName localhost" >> /etc/apache2/conf-enabled/hostname.conf && \
 # configure runit
 RUN mkdir -p /etc/service/apache
 ADD config/scripts/run_apache.sh /etc/service/apache/run
-ADD config/scripts/init_letsencrypt.sh /etc/my_init.d/
+ADD config/scripts/init_letsencrypt.sh /init_letsencrypt.sh
 ADD config/scripts/run_letsencrypt.sh /run_letsencrypt.sh
-RUN chmod +x /*.sh && chmod +x /etc/my_init.d/*.sh && chmod +x /etc/service/apache/*
+RUN chmod +x /*.sh && chmod +x /etc/service/apache/*
 
 # Cron
 ADD config/crontab /etc/crontab

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -24,7 +24,7 @@ RUN apt-get -y update && \
     # Add modsecurity
     apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
     # Add cron & python
-    apt-get install -q -y --no-install-recommends  cron python-setuptools python3-pip rsyslog && \ 
+    apt-get install -q -y --no-install-recommends  cron python-setuptools python3-pip rsyslog git && \ 
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -23,8 +23,8 @@ RUN apt-get -y update && \
     apt-get install -q -y python-certbot-apache && \
     # Add modsecurity
     apt-get install -q -y --no-install-recommends  libapache2-mod-security2 modsecurity-crs && \    
-    # Add cron 
-    apt-get install -q -y --no-install-recommends  cron  && \ 
+    # Add cron & python
+    apt-get install -q -y --no-install-recommends  cron python-setuptools python-pip && \ 
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -17,7 +17,7 @@ ENV WEBMASTER_MAIL ""
 
 # Base setup
 RUN apt-get -y update && \
-    apt-get install -q -y curl apache2 software-properties-common && \
+    apt-get install -q -y curl apache2 software-properties-common dumb-init && \
     add-apt-repository ppa:certbot/certbot && \
     apt-get -y update && \
     apt-get install -q -y python-certbot-apache && \
@@ -59,6 +59,7 @@ RUN mkdir /var/log/supervisor/
 EXPOSE 80
 EXPOSE 443
 
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["supervisord","-n","-c","/etc/supervisord.conf"]
 
 #VOLUME [ "$LETSENCRYPT_HOME", "/etc/apache2/sites-available", "/var/log/apache2" ]

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -15,8 +15,6 @@ RUN echo $WEBMASTER_MAIL > /etc/container_environment/WEBMASTER_MAIL && \
     echo $DOMAINS > /etc/container_environment/DOMAINS && \
     echo $LETSENCRYPT_HOME > /etc/container_environment/LETSENCRYPT_HOME
 
-#CMD ["/sbin/my_init"]
-
 # Base setup
 RUN apt-get -y update && \
     apt-get install -q -y curl apache2 software-properties-common && \
@@ -59,6 +57,8 @@ ADD config/rsyslog.conf /etc/rsyslog.conf
 # Stuff
 EXPOSE 80
 EXPOSE 443
+
+CMD ["supervisord","-n","-c","/etc/supervisord.conf"]
 
 #VOLUME [ "$LETSENCRYPT_HOME", "/etc/apache2/sites-available", "/var/log/apache2" ]
 HEALTHCHECK CMD curl --fail http://localhost/ || exit 1

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -1,4 +1,4 @@
-FROM  balenalib/armv7hf-debian:buster
+FROM balenalib/raspberrypi3-ubuntu:latest-run
 
 # Enable building ARM container on x86 machinery on the web (comment out next line if built on Raspberry)
 RUN [ "cross-build-start" ]

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -53,6 +53,7 @@ ADD config/crontab /etc/crontab
 # Supervisor 
 ADD config/supervisord.conf /etc/supervisord.conf
 ADD config/rsyslog.conf /etc/rsyslog.conf
+RUN mkdir /var/log/supervisor/
 
 # Stuff
 EXPOSE 80

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -44,6 +44,8 @@ ADD config/scripts/init_letsencrypt.sh /etc/my_init.d/
 ADD config/scripts/run_letsencrypt.sh /run_letsencrypt.sh
 RUN chmod +x /*.sh && chmod +x /etc/my_init.d/*.sh && chmod +x /etc/service/apache/*
 
+ADD config/crontab /etc/crontab
+
 # Stuff
 EXPOSE 80
 EXPOSE 443

--- a/Dockerfile-rpi
+++ b/Dockerfile-rpi
@@ -64,7 +64,7 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["supervisord","-n","-c","/etc/supervisord.conf"]
 
 #VOLUME [ "$LETSENCRYPT_HOME", "/etc/apache2/sites-available", "/var/log/apache2" ]
-HEALTHCHECK CMD curl --fail http://localhost/ || exit 1
+HEALTHCHECK CMD curl --fail http://localhost/ || curl -k --fail https://localhost/ || exit 1
 
 # stop processing ARM emulation (comment out next line if built on Raspberry)
 RUN [ "cross-build-end" ]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are some things you have to care about in your apache-config if you want t
 For an easy test-startup you just have to:
 
 ```
-$ docker run -d --name apache-ssl birgerk/apache-letsencrypt
+$ docker run -d --name apache-ssl nricheton/docker-apache-security-letsencrypt
 ```
 
 Now you have locally an apache running, which gets it SSL-certificates from Let's Encrypt.

--- a/config/conf-available/security.conf
+++ b/config/conf-available/security.conf
@@ -5,11 +5,11 @@
 # This currently breaks the configurations that come with some web application
 # Debian packages.
 #
-#<Directory />
-#   AllowOverride None
-#   Order Deny,Allow
-#   Deny from all
-#</Directory>
+<Directory />
+   AllowOverride None
+   Order Deny,Allow
+   Deny from all
+</Directory>
 
 
 # Changing the following options will not really affect the security of the
@@ -61,14 +61,14 @@ TraceEnable Off
 # else than declared by the content type in the HTTP headers.
 # Requires mod_headers to be enabled.
 #
-#Header set X-Content-Type-Options: "nosniff"
+Header set X-Content-Type-Options: "nosniff"
 
 #
 # Setting this header will prevent other sites from embedding pages from this
 # site as frames. This defends against clickjacking attacks.
 # Requires mod_headers to be enabled.
 #
-#Header set X-Frame-Options: "sameorigin"
+Header set X-Frame-Options: "sameorigin"
 
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/config/crontab
+++ b/config/crontab
@@ -1,1 +1,1 @@
-42 0 1 * * letsencrypt renew >/dev/null 2>&1
+42 0 1 * * root letsencrypt renew >/dev/null 2>&1

--- a/config/crontab
+++ b/config/crontab
@@ -1,1 +1,1 @@
-42 0 * * * letsencrypt renew >/dev/null 2>&1
+42 0 1 * * letsencrypt renew >/dev/null 2>&1

--- a/config/crontab
+++ b/config/crontab
@@ -1,1 +1,1 @@
-42 0 1 * * root letsencrypt renew >/dev/null 2>&1
+42 0 1 * * root /run_letsencrypt.sh --domains $DOMAINS >/log/cron-letsencrypt.log 2>&1

--- a/config/crontab
+++ b/config/crontab
@@ -1,0 +1,1 @@
+42 0 * * * letsencrypt renew >/dev/null 2>&1

--- a/config/crontab
+++ b/config/crontab
@@ -1,1 +1,1 @@
-42 0 1 * * root /run_letsencrypt.sh --domains $DOMAINS >/log/cron-letsencrypt.log 2>&1
+42 0 1 * * root /run_letsencrypt.sh --domains "$DOMAINS" >/log/cron-letsencrypt.log 2>&1

--- a/config/rsyslog.conf
+++ b/config/rsyslog.conf
@@ -1,0 +1,12 @@
+# http://www.rsyslog.com/doc/
+
+$ModLoad immark.so
+
+module(load="imuxsock")
+input(type="imuxsock" Socket="/var/run/rsyslog/dev/log" CreatePath="on")
+
+# Output modes
+$ModLoad omstdout.so       # provide messages to stdout
+
+# Actions
+*.* :omstdout:             # send everything to stdout

--- a/config/rsyslog.conf
+++ b/config/rsyslog.conf
@@ -1,12 +1,8 @@
 # http://www.rsyslog.com/doc/
-
-$ModLoad immark.so
+# Minimal config for Docker: receive syslog from /dev/log and forward to stdout
 
 module(load="imuxsock")
-input(type="imuxsock" Socket="/var/run/rsyslog/dev/log" CreatePath="on")
+input(type="imuxsock" Socket="/dev/log")
 
-# Output modes
-$ModLoad omstdout.so       # provide messages to stdout
-
-# Actions
-*.* :omstdout:             # send everything to stdout
+# Forward everything to stdout (omfile, always available)
+*.* action(type="omfile" file="/dev/stdout")

--- a/config/scripts/docker-entrypoint.sh
+++ b/config/scripts/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Run one-time Let's Encrypt initialization (no-op if already done or DOMAINS not set)
+/init_letsencrypt.sh
+
+# Hand off to supervisord which manages apache, cron, rsyslog
+exec supervisord -n -c /etc/supervisord.conf

--- a/config/scripts/init_letsencrypt.sh
+++ b/config/scripts/init_letsencrypt.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 # init only if lets-encrypt is running for the first time and if DOMAINS was set
-if ([ ! -d $LETSENCRYPT_HOME ] || [ ! "$(ls -A $LETSENCRYPT_HOME)" ]) && [ ! -z "$DOMAINS" ]; then
-  /run_letsencrypt.sh --domains $DOMAINS
+if ([ ! -d "$LETSENCRYPT_HOME" ] || [ ! "$(ls -A "$LETSENCRYPT_HOME")" ]) && [ -n "$DOMAINS" ]; then
+  if ! echo "$DOMAINS" | grep -qE '^[a-zA-Z0-9._,:-]+$'; then
+    echo "ERROR: DOMAINS contains invalid characters: $DOMAINS" >&2
+    exit 1
+  fi
+  /run_letsencrypt.sh --domains "$DOMAINS"
 fi

--- a/config/scripts/run_apache.sh
+++ b/config/scripts/run_apache.sh
@@ -1,22 +1,18 @@
 #!/bin/bash
 source /etc/apache2/envvars
 
+# If Apache is already running (e.g. started by certbot during first-boot
+# certificate request), stop the background daemon cleanly before supervisord
+# takes over in foreground mode. Running two Apache instances would cause a
+# port conflict and supervisord would mark the service as failed.
 if [ -f /var/run/apache2/apache2.pid ]; then
     apachePid=$(cat /var/run/apache2/apache2.pid)
-    echo "Found file 'apache2.pid' with pid $apachePid. Let's check if there is a process belonging to it!"
-    processName=$(ps -p $apachePid -o comm)
-
-    if [ "$processName" != "apache2" ] && [ "$processName" != "/usr/sbin/apache2 -D FOREGROUND" ]; then
-        echo "The found apache.pid is not belonging to an apache-process. I'm going to remove the pid-file."
-        rm -f /var/run/apache2/apache2.pid
-        echo "Removing of pid-file was successfull."
-
-        echo "For cleaning-reasons I'm also killing all apache-processes."
-        killall -9 apache2
-        echo "Now this is a safe place again. Enjoy."
-      else
-        echo "The pid-file is belonging to an apache-process, so it will stay alive."
+    if kill -0 "$apachePid" 2>/dev/null; then
+        echo "Apache daemon already running (pid $apachePid), stopping before foreground handoff"
+        apache2ctl stop 2>/dev/null || kill "$apachePid" 2>/dev/null || true
+        sleep 1
     fi
+    rm -f /var/run/apache2/apache2.pid
 fi
 
 exec /usr/sbin/apache2 -D FOREGROUND

--- a/config/scripts/run_letsencrypt.sh
+++ b/config/scripts/run_letsencrypt.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
-if (! [ -z "$STAGING" ]) then
+
+if [ -z "$WEBMASTER_MAIL" ]; then
+  echo "ERROR: WEBMASTER_MAIL is not set" >&2
+  exit 1
+fi
+if ! echo "$WEBMASTER_MAIL" | grep -qE '^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$'; then
+  echo "ERROR: WEBMASTER_MAIL is not a valid email address" >&2
+  exit 1
+fi
+
+if [ -n "$STAGING" ]; then
   echo "Using Let's Encrypt Staging environment..."
-  certbot -n --staging --expand --apache --agree-tos --email $WEBMASTER_MAIL "$@"
+  certbot -n --staging --expand --apache --agree-tos --email "$WEBMASTER_MAIL" "$@"
 else
   echo "Using Let's Encrypt Production environment..."
-  certbot -n --expand --apache --agree-tos --email $WEBMASTER_MAIL "$@"
+  certbot -n --expand --apache --agree-tos --email "$WEBMASTER_MAIL" "$@"
 fi

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -8,7 +8,7 @@ logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=10           ; (num of main logfile rotation backups;default 10)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
 pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-nodaemon=false               ; (start in foreground if true;default false)
+nodaemon=true               ; (start in foreground if true;default false)
 minfds=1024                  ; (min. avail startup file descriptors;default 1024)
 minprocs=200                 ; (min. avail process descriptors;default 200)
 

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -1,0 +1,52 @@
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+
+[supervisord]
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+childlogdir=/var/log/supervisor/
+logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_backups=10           ; (num of main logfile rotation backups;default 10)
+loglevel=info                ; (log level;default info; others: debug,warn,trace)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+nodaemon=false               ; (start in foreground if true;default false)
+minfds=1024                  ; (min. avail startup file descriptors;default 1024)
+minprocs=200                 ; (min. avail process descriptors;default 200)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[program:apache2]
+command=/etc/service/apache/run
+priority=900
+autostart=true
+startretries=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[program:cron]
+autorestart=false
+command=cron -f
+autostart=true
+startretries=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[program:rsyslog]
+command=/usr/sbin/rsyslogd -n
+priority=800
+autostart=true
+startretries=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -26,6 +26,8 @@ command=/etc/service/apache/run
 priority=900
 autostart=true
 startretries=0
+killasgroup=true
+stopasgroup=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
@@ -34,6 +36,8 @@ autorestart=false
 command=cron -f
 autostart=true
 startretries=0
+killasgroup=true
+stopasgroup=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
@@ -42,6 +46,8 @@ command=/usr/sbin/rsyslogd -n
 priority=800
 autostart=true
 startretries=0
+killasgroup=true
+stopasgroup=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -1,5 +1,7 @@
 [unix_http_server]
 file=/var/run/supervisor.sock   ; (the path to the socket file)
+chmod=0700                      ; restrict socket to owner (root) only — real security is here
+chown=root:root                 ; ensure root owns the socket
 
 [supervisord]
 logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
@@ -11,6 +13,7 @@ pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=true               ; (start in foreground if true;default false)
 minfds=1024                  ; (min. avail startup file descriptors;default 1024)
 minprocs=200                 ; (min. avail process descriptors;default 200)
+user=root                    ; suppress "running as root, no user specified" CRIT message
 
 ; the below section must remain in the config file for RPC
 ; (supervisorctl/web interface) to work, additional interfaces may be
@@ -51,8 +54,4 @@ stopasgroup=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
-[eventlistener:stdout]
-command = supervisor_stdout
-buffer_size = 100
-events = PROCESS_LOG
-result_handler = supervisor_stdout:event_handler
+; stdout forwarding is handled via stdout_logfile=/dev/stdout on each program


### PR DESCRIPTION
- Drop `phusion/baseimage` (removed SSH daemon, `my_init`, Ubuntu bloat); switch to `debian:bookworm-slim` + `supervisord` + `dumb-init`
- Fix command injection in init scripts (variable quoting + domain/email regex validation)
- Enable Apache security headers and filesystem restrictions (`X-Content-Type-Options`, `X-Frame-Options`)
- Fix healthcheck: tolerate 403, silent output, 120s start-period for first-boot Let's Encrypt; fix port conflict with certbot daemon handoff

## Test plan

- [x] Image builds on `linux/amd64` and `linux/arm64`
- [x] Container starts healthy with no configuration (no certs, no sites)
- [x] All services reach `RUNNING` state (apache2, cron, rsyslog)
- [x] No `CRIT` errors from supervisord at startup (except expected socket auth notice)
- [x] Healthcheck passes silently (`Output: ""`) within start-period
- [x] Validated with full `cap_drop: ALL` + minimal capability set